### PR TITLE
#issue-42,43,44 `npm run build` が失敗する, `8080` にアクセスできない, `composer install` が失敗する

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 
 ![image](https://user-images.githubusercontent.com/44870505/230751655-be56e246-6910-4a1b-8b2d-4d9d160d6028.png)
 
-
 ## 1. PHP ライブラリの install
 
 ```
@@ -37,7 +36,7 @@ docker compose exec app bash
 ```
 
 でコンテナの中に入る。
-コンテナに入れたら、入った直後のカレントディレクトリで composer install を実行
+コンテナに入れたら、入った直後のカレントディレクトリで composer self-update を実行し、 composer install を実行
 
 ## 2. .env を設定
 
@@ -102,13 +101,14 @@ php artisan migrate:fresh --seed
 ## 8. 仕上げ
 
 ```
+npm install
 npm run build
 php artisan key:generate
 ```
 
 と入力してキーを生成後、
 
-http:127.0.0.1:8080
+http:127.0.0.1:8085
 
 より確認。
 


### PR DESCRIPTION
https://github.com/ysknsid25/otaku-tool/issues/44
https://github.com/ysknsid25/otaku-tool/issues/43
https://github.com/ysknsid25/otaku-tool/issues/42

上記のIssueを行いました。

## 変更点

`README.md`を変更し、Issueの解決方法を追記しました。